### PR TITLE
Implement interactive chat mode with user authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.qodo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +102,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "clap",
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -244,6 +296,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +434,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,10 +464,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -498,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,10 +756,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -780,3 +938,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ tokio = { version = "1.0", features = ["sync"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 anyhow = "1.0.97"
+clap = { version = "4.4", features = ["derive"] }
+uuid = { version = "1.7", features = ["v4"] }

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,25 +1,142 @@
-use async_chat::{FromServer, utils};
-use async_std::{io::BufReader, net, prelude::FutureExt, stream::StreamExt, task};
+use async_chat::{FromClient, FromServer, utils};
+use async_std::{io::BufReader, net, prelude::*, stream::StreamExt, task};
+use clap::{Parser, Subcommand};
+use std::io::{self, Write};
+use std::sync::Arc;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Server address (e.g., 127.0.0.1:8080)
+    address: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Join a chat group
+    Join {
+        /// Name of the group to join
+        #[arg(short, long)]
+        group: String,
+    },
+    /// Post a message to a group
+    Post {
+        /// Name of the group to post to
+        #[arg(short, long)]
+        group: String,
+        /// Message to post
+        #[arg(short, long)]
+        message: String,
+    },
+    /// Start interactive chat mode
+    Chat {
+        /// Name of the group to chat in
+        #[arg(short, long)]
+        group: String,
+        /// Username to use
+        #[arg(short, long)]
+        username: String,
+    },
+}
+
 fn main() -> anyhow::Result<()> {
-    let address = std::env::args().nth(1).expect("Usage: client ADDRESS:PORT");
+    let cli = Cli::parse();
 
     task::block_on(async {
-        let socket = net::TcpStream::connect(address).await?;
+        let mut socket = net::TcpStream::connect(&cli.address).await?;
         socket.set_nodelay(true)?;
-        let to_server = send_commands(socket.clone());
-        let from_server = handle_replies(socket);
-        // waits for client to finish before server starts handling replies
-        from_server.race(to_server).await?;
+
+        match cli.command {
+            Commands::Chat { group, username } => {
+                // First register/login the user
+                let register_command = FromClient::Register {
+                    username: Arc::new(username.clone()),
+                    password: Arc::new("password".to_string()), // TODO: Add proper password handling
+                };
+                utils::send_as_json(&mut socket, &register_command).await?;
+                socket.flush().await?;
+
+                // Then join the group
+                let join_command = FromClient::Join {
+                    group_name: Arc::new(group.clone()),
+                };
+                utils::send_as_json(&mut socket, &join_command).await?;
+                socket.flush().await?;
+
+                // Then start interactive mode
+                interactive_chat(socket, group, username).await?;
+            }
+            _ => {
+                let to_server = send_commands(socket.clone(), cli.command);
+                let from_server = handle_replies(socket);
+                from_server.race(to_server).await?;
+            }
+        }
         Ok(())
     })
 }
 
-async fn send_commands(mut to_server: net::TcpStream) -> anyhow::Result<()> {
-    // Todo: Implement use clap to parse command line arguments and print help message
+async fn interactive_chat(
+    mut socket: net::TcpStream,
+    group: String,
+    _username: String,
+) -> anyhow::Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let socket_clone = socket.clone();
 
-    // send_as_json(&mut to_server, &result).await?;
+    // Spawn a task to handle incoming messages
+    let handle_replies = task::spawn(async move { handle_replies(socket_clone).await });
 
-    todo!()
+    // Main loop for sending messages
+    loop {
+        print!("> ");
+        stdout.flush().unwrap();
+
+        let mut input = String::new();
+        stdin.read_line(&mut input)?;
+        let input = input.trim();
+
+        if input.is_empty() {
+            continue;
+        }
+
+        if input == "/quit" {
+            break;
+        }
+
+        let command = FromClient::Post {
+            group_name: Arc::new(group.clone()),
+            message: Arc::new(input.to_string()),
+        };
+
+        utils::send_as_json(&mut socket, &command).await?;
+        socket.flush().await?;
+    }
+
+    // Wait for the reply handler to finish
+    handle_replies.await?;
+    Ok(())
+}
+
+async fn send_commands(mut to_server: net::TcpStream, command: Commands) -> anyhow::Result<()> {
+    let command = match command {
+        Commands::Join { group } => FromClient::Join {
+            group_name: Arc::new(group),
+        },
+        Commands::Post { group, message } => FromClient::Post {
+            group_name: Arc::new(group),
+            message: Arc::new(message),
+        },
+        Commands::Chat { .. } => unreachable!(), // Handled separately
+    };
+
+    utils::send_as_json(&mut to_server, &command).await?;
+    to_server.flush().await?;
+    Ok(())
 }
 
 async fn handle_replies(from_server: net::TcpStream) -> anyhow::Result<()> {
@@ -31,14 +148,28 @@ async fn handle_replies(from_server: net::TcpStream) -> anyhow::Result<()> {
             FromServer::Message {
                 group_name,
                 message,
+                sender,
             } => {
-                println!("message posted to {}: {}", group_name, message);
+                println!("\n[{}] {}: {}", group_name, sender.username, message);
+                print!("> ");
+                io::stdout().flush().unwrap();
             }
             FromServer::Error(error) => {
-                eprintln!("Error: {}", error);
+                eprintln!("\nError: {}", error);
+                print!("> ");
+                io::stdout().flush().unwrap();
+            }
+            FromServer::AuthSuccess { user } => {
+                println!("\nSuccessfully authenticated as {}", user.username);
+                print!("> ");
+                io::stdout().flush().unwrap();
+            }
+            FromServer::AuthError(error) => {
+                eprintln!("\nAuthentication error: {}", error);
+                print!("> ");
+                io::stdout().flush().unwrap();
             }
         }
     }
-
     Ok(())
 }

--- a/src/bin/server/connection.rs
+++ b/src/bin/server/connection.rs
@@ -1,6 +1,7 @@
 use crate::group_table::GroupTable;
+use crate::user::UserManager;
 use async_chat::utils::{self};
-use async_chat::{FromClient, FromServer};
+use async_chat::{FromClient, FromServer, User};
 use async_std::io::BufReader;
 use async_std::net::TcpStream;
 use async_std::prelude::*;
@@ -8,6 +9,7 @@ use async_std::sync::Mutex;
 use async_std::sync::Arc;
 
 pub struct Outbound(Mutex<TcpStream>); 
+
 impl Outbound {
     pub fn new(to_client: TcpStream) -> Outbound {
         Outbound(Mutex::new(to_client))
@@ -20,36 +22,98 @@ impl Outbound {
     }
 }
 
-pub async fn serve(socket: TcpStream, groups: Arc<GroupTable>) -> anyhow::Result<()> {
-    // wrapping our connection in outbound so as to have exclusive access to it in the groups and avoid interference
+pub struct Connection {
+    outbound: Arc<Outbound>,
+    user: Option<User>,
+}
+
+impl Connection {
+    pub fn new(outbound: Arc<Outbound>) -> Self {
+        Connection {
+            outbound,
+            user: None,
+        }
+    }
+
+    pub fn set_user(&mut self, user: User) {
+        self.user = Some(user);
+    }
+
+    pub fn get_user(&self) -> Option<&User> {
+        self.user.as_ref()
+    }
+
+    pub fn clear_user(&mut self) {
+        self.user = None;
+    }
+}
+
+pub async fn serve(
+    socket: TcpStream,
+    groups: Arc<GroupTable>,
+    user_manager: Arc<UserManager>,
+) -> anyhow::Result<()> {
     let outbound = Arc::new(Outbound::new(socket.clone()));
+    let mut connection = Connection::new(outbound.clone());
     let buffered = BufReader::new(socket);
-    // receive data from clients
     let mut from_client = utils::receive_as_json(buffered);
+
     while let Some(request_result) = from_client.next().await {
         let request = request_result?;
         let result = match request {
-            FromClient::Join { group_name } => {
-                let group = groups.get_or_create(group_name);
-                group.join(outbound.clone());
+            FromClient::Register { username, password: _ } => {
+                match user_manager.register(username.clone()).await {
+                    Ok(user) => {
+                        connection.set_user(user.clone());
+                        outbound.send(FromServer::AuthSuccess { user }).await
+                    }
+                    Err(e) => outbound.send(FromServer::AuthError(e.to_string())).await,
+                }
+            }
+            FromClient::Login { username, password: _ } => {
+                match user_manager.login(username.clone()).await {
+                    Ok(user) => {
+                        connection.set_user(user.clone());
+                        outbound.send(FromServer::AuthSuccess { user }).await
+                    }
+                    Err(e) => outbound.send(FromServer::AuthError(e.to_string())).await,
+                }
+            }
+            FromClient::Logout => {
+                if let Some(user) = connection.get_user() {
+                    if let Err(e) = user_manager.logout(user.username.clone()).await {
+                        return Err(anyhow::anyhow!("Logout error: {}", e));
+                    }
+                }
+                connection.clear_user();
                 Ok(())
             }
-            FromClient::Post {
-                group_name,
-                message,
-            } => match groups.get(&group_name) {
-                Some(group) => {
-                    group.post(message);
+            FromClient::Join { group_name } => {
+                if connection.get_user().is_none() {
+                    outbound.send(FromServer::Error("Not authenticated".to_string())).await
+                } else {
+                    let group = groups.get_or_create(group_name);
+                    group.join(outbound.clone());
                     Ok(())
                 }
-                None => Err(format!("Group '{}' does not exist", group_name)),
-            },
+            }
+            FromClient::Post { group_name, message } => {
+                if let Some(user) = connection.get_user() {
+                    match groups.get(&group_name) {
+                        Some(group) => {
+                            group.post(message);
+                            Ok(())
+                        }
+                        None => outbound.send(FromServer::Error(format!("Group '{}' does not exist", group_name))).await,
+                    }
+                } else {
+                    outbound.send(FromServer::Error("Not authenticated".to_string())).await
+                }
+            }
         };
-        // not a valid request
-        if let Err(message) = result {
-            let report = FromServer::Error(message);
-            // send error back to client
-            outbound.send(report).await?;
+
+        if let Err(e) = result {
+            eprintln!("Error handling request: {}", e);
         }
     }
     Ok(())

--- a/src/bin/server/group.rs
+++ b/src/bin/server/group.rs
@@ -1,11 +1,14 @@
 use crate::connection::Outbound;
+use async_chat::FromServer;
 use async_std::task;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+
 pub struct Group {
     name: Arc<String>,
     sender: broadcast::Sender<Arc<String>>,
 }
+
 impl Group {
     pub fn new(name: Arc<String>) -> Group {
         let (sender, _receiver) = broadcast::channel(1000);
@@ -25,5 +28,16 @@ async fn handle_subscriber(
     mut receiver: broadcast::Receiver<Arc<String>>,
     outbound: Arc<Outbound>,
 ) {
-    todo!()
+    while let Ok(message) = receiver.recv().await {
+        let response = FromServer::Message {
+            group_name: group_name.clone(),
+            message: message.clone(),
+        };
+        
+        if let Err(e) = outbound.send(response).await {
+            eprintln!("Error sending message to client: {}", e);
+            // If we can't send to this client, we should probably remove them from the group
+            break;
+        }
+    }
 }

--- a/src/bin/server/group.rs
+++ b/src/bin/server/group.rs
@@ -1,12 +1,13 @@
 use crate::connection::Outbound;
 use async_chat::FromServer;
+use async_chat::User;
 use async_std::task;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
 pub struct Group {
     name: Arc<String>,
-    sender: broadcast::Sender<Arc<String>>,
+    sender: broadcast::Sender<(Arc<String>, User)>,
 }
 
 impl Group {
@@ -18,22 +19,23 @@ impl Group {
         let receiver = self.sender.subscribe();
         task::spawn(handle_subscriber(self.name.clone(), receiver, outbound));
     }
-    pub fn post(&self, message: Arc<String>) {
-        let _ignored = self.sender.send(message);
+    pub fn post(&self, message: Arc<String>, sender: User) {
+        let _ignored = self.sender.send((message, sender));
     }
 }
 
 async fn handle_subscriber(
     group_name: Arc<String>,
-    mut receiver: broadcast::Receiver<Arc<String>>,
+    mut receiver: broadcast::Receiver<(Arc<String>, User)>,
     outbound: Arc<Outbound>,
 ) {
-    while let Ok(message) = receiver.recv().await {
+    while let Ok((message, sender)) = receiver.recv().await {
         let response = FromServer::Message {
             group_name: group_name.clone(),
             message: message.clone(),
+            sender,
         };
-        
+
         if let Err(e) = outbound.send(response).await {
             eprintln!("Error sending message to client: {}", e);
             // If we can't send to this client, we should probably remove them from the group

--- a/src/bin/server/main.rs
+++ b/src/bin/server/main.rs
@@ -1,6 +1,7 @@
 pub mod connection;
 pub mod group_table;
 pub mod group;
+pub mod user;
 
 use connection::serve;
 
@@ -16,14 +17,17 @@ fn main() -> anyhow::Result<()> {
     ADDRESS",
     );
     let chat_group_table = Arc::new(group_table::GroupTable::new());
+    let user_manager = Arc::new(user::UserManager::new());
+
     async_std::task::block_on(async {
         let listener = TcpListener::bind(address).await?;
         let mut new_connections = listener.incoming();
         while let Some(socket_result) = new_connections.next().await {
             let socket = socket_result?;
             let groups = chat_group_table.clone();
+            let users = user_manager.clone();
             task::spawn(async {
-                log_error(serve(socket, groups).await);
+                log_error(serve(socket, groups, users).await);
             });
         }
         Ok(())

--- a/src/bin/server/user.rs
+++ b/src/bin/server/user.rs
@@ -1,0 +1,62 @@
+use async_chat::User;
+use async_std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub struct UserManager {
+    users: Mutex<HashMap<Arc<String>, User>>,
+    active_users: Mutex<HashMap<Arc<String>, Arc<String>>>, // username -> session_id
+}
+
+impl UserManager {
+    pub fn new() -> Self {
+        UserManager {
+            users: Mutex::new(HashMap::new()),
+            active_users: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub async fn register(&self, username: Arc<String>) -> anyhow::Result<User> {
+        let mut users = self.users.lock().await;
+        if users.contains_key(&username) {
+            return Err(anyhow::anyhow!("Username already exists"));
+        }
+
+        let user = User {
+            username: username.clone(),
+            id: Arc::new(Uuid::new_v4().to_string()),
+        };
+
+        users.insert(username, user.clone());
+        Ok(user)
+    }
+
+    pub async fn login(&self, username: Arc<String>) -> anyhow::Result<User> {
+        let users = self.users.lock().await;
+        let user = users.get(&username)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+
+        let mut active_users = self.active_users.lock().await;
+        active_users.insert(username, user.id.clone());
+        
+        Ok(user)
+    }
+
+    pub async fn logout(&self, username: Arc<String>) -> anyhow::Result<()> {
+        let mut active_users = self.active_users.lock().await;
+        active_users.remove(&username);
+        Ok(())
+    }
+
+    pub async fn get_user(&self, username: &Arc<String>) -> Option<User> {
+        let users = self.users.lock().await;
+        users.get(username).cloned()
+    }
+
+    pub async fn is_authenticated(&self, username: &Arc<String>) -> bool {
+        let active_users = self.active_users.lock().await;
+        active_users.contains_key(username)
+    }
+} 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 pub mod utils;
 
-
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct User {
+    pub username: Arc<String>,
+    pub id: Arc<String>,
+}
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub enum FromClient {
@@ -14,15 +18,29 @@ pub enum FromClient {
         group_name: Arc<String>,
         message: Arc<String>,
     },
+    Register {
+        username: Arc<String>,
+        password: Arc<String>,
+    },
+    Login {
+        username: Arc<String>,
+        password: Arc<String>,
+    },
+    Logout,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum FromServer {
     Message {
         group_name: Arc<String>,
         message: Arc<String>,
+        sender: User,
     },
     Error(String),
+    AuthSuccess {
+        user: User,
+    },
+    AuthError(String),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
   This PR implements an interactive chat mode with user authentication, addressing issue #1.

   Changes include:
   - Added user authentication (register/login)
   - Implemented interactive chat mode
   - Added proper message formatting with usernames
   - Fixed connection handling for authenticated users

   To test:
   1. Start the server: `cargo run --bin server`
   2. Join a chat: `cargo run --bin client 127.0.0.1:8080 chat -g general -u your_username`