### PR TITLE
chore(ci): add DCO check GitHub Action

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,36 @@
+name:  DCO Check
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  dco-check:
+    name:  Verify DCO Sign-off
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name:  Get latest commit message
+        id: get_commit
+        run: |
+          message=$(git log -1 --pretty=format:"%B")
+          echo "commit_msg<<EOF" >> $GITHUB_OUTPUT
+          echo "$message" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name:  Check for Signed-off-by line
+        run: |
+          echo " Checking commit message:"
+          echo "${{ steps.get_commit.outputs.commit_msg }}"
+          if [[ "${{ steps.get_commit.outputs.commit_msg }}" != *"Signed-off-by:"* ]]; then
+            echo " DCO sign-off missing!"
+            exit 1
+          else
+            echo " DCO sign-off present."
+          fi
+

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,22 @@
+Thank you for considering contributing! 🚀  
+This project follows the **Developer Certificate of Origin (DCO)**, which requires all commits to be signed off.
+
+✅ How to sign off:
+
+If you're using the command line:
+
+```
+git commit -s -m "Commit message"
+```
+This adds:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+If you forget, no stress — you can fix it:
+
+```
+git commit --amend -s
+git push --force
+```


### PR DESCRIPTION
Adds a GitHub Actions workflow that checks for Signed-off-by lines in commit messages to enforce DCO compliance.